### PR TITLE
fix(main): add pointer to theme selector options

### DIFF
--- a/src/theme/ThemeSelector.tsx
+++ b/src/theme/ThemeSelector.tsx
@@ -52,6 +52,7 @@ export const StyledThemeSelector = styled(Select)`
 
         .select__option {
             background-color: ${props => props.theme.primaryBackground};
+            cursor: pointer;
             &:hover {
                 background-color: ${props => props.theme.secondaryBackground};
             }


### PR DESCRIPTION
### Summary
This adds the pointer to the theme selector options as described in bug #9 

### Changes
1. Adds `cursor: pointer` to the theme selector item styled component.

### Todo
- [x] Complete change
- [x] Test change